### PR TITLE
Switch to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@icure/api": "^8.0.61",
     "lodash": "^4.17.20"
   },
+  "peerDependencies": {
+    "@icure/api": "~8.1.2"
+  },
   "devDependencies": {
+    "@icure/api": "~8.1.2",
     "@types/chai": "^4.1.4",
     "@types/form-data": "^2.2.1",
     "@types/lodash": "^4.14.182",
@@ -33,7 +36,7 @@
     "build": "tsc",
     "install": "tsc",
     "prepublish": "rm -rf dist && tsc",
-    "prepare": "rimraf dist && npm run build && jq '{name:.name, version:.version, description:.description, main:\"index.js\", types:\"index.d.ts\", dependencies:.dependencies, author:.author, license:.license, bugs:.bugs, homepage:.homepage}' < package.json > dist/package.json",
+    "prepare": "rimraf dist && npm run build && jq '{name:.name, version:.version, description:.description, main:\"index.js\", types:\"index.d.ts\", dependencies:.dependencies, peerDependencies:.peerDependencies, author:.author, license:.license, bugs:.bugs, homepage:.homepage}' < package.json > dist/package.json",
     "publish": "yarn version patch && yarn run prepare && cd dist && npm publish && cd ..",
     "precommit": "pretty-quick --staged"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,20 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@icure/api@npm:^8.0.61":
-  version: 8.0.61
-  resolution: "@icure/api@npm:8.0.61"
+"@babel/runtime@npm:^7.21.0":
+  version: 7.26.7
+  resolution: "@babel/runtime@npm:7.26.7"
   dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10c0/60199c049f90e5e41c687687430052a370aca60bac7859ff4ee761c5c1739b8ba1604d391d01588c22dc0e93828cbadb8ada742578ad1b1df240746bce98729a
+  languageName: node
+  linkType: hard
+
+"@icure/api@npm:~8.1.2":
+  version: 8.1.2
+  resolution: "@icure/api@npm:8.1.2"
+  dependencies:
+    async-mutex: "npm:^0.5.0"
     big-integer: "npm:^1.6.52"
     browser-or-node: "npm:^3.0.0"
     date-fns: "npm:^2.23.0"
@@ -18,7 +28,8 @@ __metadata:
     text-encoding: "npm:^0.7.0"
     uuid: "npm:^8.3.2"
     uuid-encoder: "npm:^1.1.0"
-  checksum: 10c0/e4f6bac32846cb4026f888af7920df884fe64ba564d284992f631a2cee7049b976dff91fc449f0ed438819da63c6d00b4a84d3697b4825d69a4b781d8bae7f95
+    ws: "npm:^8.18.0"
+  checksum: 10c0/6d150d423d7f72d2b48ec1544126bf0265f7a567cd5a335220f43da45332033c7f81b58399eadf2b0f8e4e105bcdd5c7c069bdc325151acf4ef03cfaa45f6c48
   languageName: node
   linkType: hard
 
@@ -26,7 +37,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@icure/be-fhc-api@workspace:."
   dependencies:
-    "@icure/api": "npm:^8.0.61"
+    "@icure/api": "npm:~8.1.2"
     "@types/chai": "npm:^4.1.4"
     "@types/form-data": "npm:^2.2.1"
     "@types/lodash": "npm:^4.14.182"
@@ -44,6 +55,8 @@ __metadata:
     rimraf: "npm:^3.0.2"
     ts-node: "npm:^7.0.1"
     typescript: "npm:^4.0.3"
+  peerDependencies:
+    "@icure/api": ~8.1.2
   languageName: unknown
   linkType: soft
 
@@ -260,6 +273,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-mutex@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "async-mutex@npm:0.5.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/9096e6ad6b674c894d8ddd5aa4c512b09bb05931b8746ebd634952b05685608b2b0820ed5c406e6569919ff5fe237ab3c491e6f2887d6da6b6ba906db3ee9c32
+  languageName: node
+  linkType: hard
+
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -281,14 +303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"big-integer@npm:^1.6.46":
-  version: 1.6.51
-  resolution: "big-integer@npm:1.6.51"
-  checksum: 10c0/c8139662d57f8833a44802f4b65be911679c569535ea73c5cfd3c1c8994eaead1b84b6f63e1db63833e4d4cacb6b6a9e5522178113dfdc8e4c81ed8436f1e8cc
-  languageName: node
-  linkType: hard
-
-"big-integer@npm:^1.6.52":
+"big-integer@npm:^1.6.46, big-integer@npm:^1.6.52":
   version: 1.6.52
   resolution: "big-integer@npm:1.6.52"
   checksum: 10c0/9604224b4c2ab3c43c075d92da15863077a9f59e5d4205f4e7e76acd0cd47e8d469ec5e5dba8d9b32aa233951893b29329ca56ac80c20ce094b4a647a66abae0
@@ -562,9 +577,11 @@ __metadata:
   linkType: hard
 
 "date-fns@npm:^2.23.0":
-  version: 2.28.0
-  resolution: "date-fns@npm:2.28.0"
-  checksum: 10c0/ecdacd36326e7f5f8c4f1e78ae931a8997109f1c841f5163053b866585ca899521b0e7a114eeb48a9fe5135a550787bd4bbd8baa321cded0b4d823f847889a80
+  version: 2.30.0
+  resolution: "date-fns@npm:2.30.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.21.0"
+  checksum: 10c0/e4b521fbf22bc8c3db332bbfb7b094fd3e7627de0259a9d17c7551e2d2702608a7307a449206065916538e384f37b181565447ce2637ae09828427aed9cb5581
   languageName: node
   linkType: hard
 
@@ -1428,9 +1445,9 @@ __metadata:
   linkType: hard
 
 "moment@npm:^2.22.1":
-  version: 2.29.1
-  resolution: "moment@npm:2.29.1"
-  checksum: 10c0/2617e383c0e0f910696214d026b9742173ea1916775d2023b39fd7d5fc3fae694f67c17876d154e246b139ad2a8028c42b2898c66cd665316b61c18453a5103f
+  version: 2.30.1
+  resolution: "moment@npm:2.30.1"
+  checksum: 10c0/865e4279418c6de666fca7786607705fd0189d8a7b7624e2e56be99290ac846f90878a6f602e34b4e0455c549b85385b1baf9966845962b313699e7cb847543a
   languageName: node
   linkType: hard
 
@@ -1740,6 +1757,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 10c0/1b16eb2c4bceb1665c89de70dcb64126a22bc8eb958feef3cd68fe11ac6d2a4899b5cd1b80b0774c7c03591dc57d16631a7f69d2daa2ec98100e2f29f7ec4cc4
+  languageName: node
+  linkType: hard
+
 "require-directory@npm:^2.1.1":
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
@@ -2040,6 +2064,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.4.0":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
 "type-detect@npm:^4.0.0, type-detect@npm:^4.0.5":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
@@ -2169,6 +2200,21 @@ __metadata:
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 10c0/56fece1a4018c6a6c8e28fbc88c87e0fbf4ea8fd64fc6c63b18f4acc4bd13e0ad2515189786dd2c30d3eec9663d70f4ecf699330002f8ccb547e4a18231fc9f0
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.0":
+  version: 8.18.0
+  resolution: "ws@npm:8.18.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Use `~` instead of `^` for dependency to `@icure/api` &rarr; Not acceptable anymore to use with a different minor version of `@icure/api`
- Use peer dependency of `@icure/api`. The project must explicitly add a dependency to a compatible version of `@icure/api`.
  - Without this change, there would be a risk in the future to install version 8.2.x alongside 8.1.y. 
  - If the user doesn't explicitly add a compatible peer dependency they will receive a warning like:
```
➤ YN0000: ┌ Post-resolution validation
➤ YN0002: │ demo@workspace:. doesn't provide @icure/api (pb2737), requested by @icure/be-fhc-api.
➤ YN0086: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
➤ YN0000: └ Completed
```